### PR TITLE
Guard against multiple employers

### DIFF
--- a/scrapers/financial_disclosure/parse_pdf.py
+++ b/scrapers/financial_disclosure/parse_pdf.py
@@ -48,7 +48,16 @@ def _parse_employer(rows: Rows) -> dict[str, str | None]:
 
     header, *body = rows
 
-    result = dict(_parse_value(value) for row in body for value in row if value)
+    result = {}
+    for row in body:
+        for value in row:
+            if not value:
+                continue
+
+            if value in result:
+                raise IndexError("Multiple employers found!")
+
+            result.update([_parse_value(value)])
 
     return result
 


### PR DESCRIPTION
## Overview

This PR makes sure we're not ignoring multiple employer declarations.

I've assumed that in the case of multiple employers, there would be two or more identical batches of employer info under the same header.

<img width="871" alt="Screen Shot 2024-01-10 at 11 48 54 AM" src="https://github.com/datamade/nmid-scrapers/assets/36973363/9d5c7b30-1a20-46e1-9317-402b4efa12be">


Closes #3 

## Testing Instructions

Verify that `python -m scrapers.financial_disclosure.scrape_financial_disclosures` runs without error and produces correct employer CSVs