### PR TITLE
Prevent iteration on pages with no tables

### DIFF
--- a/scrapers/financial_disclosure/parse_pdf.py
+++ b/scrapers/financial_disclosure/parse_pdf.py
@@ -85,7 +85,13 @@ def parse_pdf(pdf: pdfplumber.PDF) -> dict[str, dict[str, str | None]]:
     table_settings = {
         "intersection_tolerance": 6, # minimum allowable tolerance to grab all tables
     }
-    rows = [tuple(row) for page in pdf.pages for row in page.extract_table(table_settings=table_settings)]  # type: ignore[union-attr]
+
+    rows = []
+    for page in pdf.pages:
+        tables = page.extract_table(table_settings=table_settings)
+        if tables != None:
+            for row in tables:
+                rows.append(tuple(row))  # type: ignore[union-attr]
 
     grouped_rows = SubstringDict(_group_rows(rows))
 

--- a/scrapers/financial_disclosure/parse_pdf.py
+++ b/scrapers/financial_disclosure/parse_pdf.py
@@ -86,12 +86,7 @@ def parse_pdf(pdf: pdfplumber.PDF) -> dict[str, dict[str, str | None]]:
         "intersection_tolerance": 6, # minimum allowable tolerance to grab all tables
     }
 
-    rows = []
-    for page in pdf.pages:
-        tables = page.extract_table(table_settings=table_settings)
-        if tables != None:
-            for row in tables:
-                rows.append(tuple(row))  # type: ignore[union-attr]
+    rows = [tuple(row) for page in pdf.pages if (table := page.extract_table(table_settings=table_settings)) for row in table]  # type: ignore[union-attr]
 
     grouped_rows = SubstringDict(_group_rows(rows))
 

--- a/scrapers/financial_disclosure/parse_pdf.py
+++ b/scrapers/financial_disclosure/parse_pdf.py
@@ -69,6 +69,15 @@ def _parse_filing_status(rows: Rows) -> dict[str, str | None]:
     return result
 
 
+def _parse_general_info(rows: Rows) -> dict[str, str | None]:
+
+    header, *body = rows
+
+    result = [{"Input": val[0]} for val in body]
+    
+    return result
+
+
 def parse_pdf(pdf: pdfplumber.PDF) -> dict[str, dict[str, str | None]]:
 
     rows = [tuple(row) for page in pdf.pages for row in page.extract_table()]  # type: ignore[union-attr]
@@ -84,5 +93,35 @@ def parse_pdf(pdf: pdfplumber.PDF) -> dict[str, dict[str, str | None]]:
         ),
         "current filing status": _parse_filing_status(
             grouped_rows["REPORTING INDIVIDUAL – Current Filing Status"]
+        ),
+        "income sources": _parse_filing_status(
+            grouped_rows["REPORTING INDIVIDUAL & REPORTING INDIVIDUAL’S SPOUSE – Income Source(s)"]
+        ),
+        "specializations": _parse_filing_status(
+            grouped_rows["REPORTING INDIVIDUAL & REPORTING INDIVIDUAL’S SPOUSE - Areas of Specialization"]
+        ),
+        "consulting or lobbying": _parse_filing_status(
+            grouped_rows["REPORTING INDIVIDUAL & REPORTING INDIVIDUAL’S SPOUSE - Consulting and/or Lobbying"]
+        ),
+        "real estate": _parse_filing_status(
+            grouped_rows["REPORTING INDIVIDUAL & REPORTING INDIVIDUAL’S SPOUSE – Real Estate"]
+        ),
+        "other business": _parse_filing_status(
+            grouped_rows["REPORTING INDIVIDUAL & REPORTING INDIVIDUAL’S SPOUSE – Other Business"]
+        ),
+        "board membership": _parse_filing_status(
+            grouped_rows["REPORTING INDIVIDUAL & REPORTING INDIVIDUAL’S SPOUSE\nBoard Membership"]
+        ),
+        "professional licenses": _parse_filing_status(
+            grouped_rows["REPORTING INDIVIDUAL & REPORTING INDIVIDUAL’S SPOUSE – Professional License(s)"]
+        ),
+        "provisions to state agencies": _parse_filing_status(
+            grouped_rows["REPORTING INDIVIDUAL & REPORTING INDIVIDUAL’S SPOUSE\nGoods and/or Services Provided to State Agencies"]
+        ),
+        "state agency representation": _parse_filing_status(
+            grouped_rows["REPORTING INDIVIDUAL & REPORTING INDIVIDUAL’S SPOUSE\nState Agency Representation"]
+        ),
+        "general info": _parse_general_info(
+            grouped_rows["REPORTING INDIVIDUAL & REPORTING INDIVIDUAL’S SPOUSE – General Information"]
         ),
     }

--- a/scrapers/financial_disclosure/scrape_financial_disclosures.py
+++ b/scrapers/financial_disclosure/scrape_financial_disclosures.py
@@ -260,30 +260,7 @@ if __name__ == "__main__":
             ],
         )
 
-        filer_writer.writeheader()
-        filing_writer.writeheader()
-        employer_writer.writeheader()
-        spouse_employer_writer.writeheader()
-        filing_status_writer.writeheader()
-        income_writer.writeheader()
-        specializations_writer.writeheader()
-        consulting_writer.writeheader()
-        real_estate_writer.writeheader()
-        business_writer.writeheader()
-        membership_writer.writeheader()
-        licenses_writer.writeheader()
-        provisions_writer.writeheader()
-        representation_writer.writeheader()
-        general_writer.writeheader()
-
-        employer_field_corrector = levenshtein_distance.SpellingCorrector(
-            employer_writer.fieldnames
-        )
-        spouse_employer_field_corrector = levenshtein_distance.SpellingCorrector(
-            spouse_employer_writer.fieldnames
-        )
-
-        # pdf fields that return lists of dicts w/ identical keys
+        # pdf fields that return lists of similarly structured dicts
         mapping_dict = {
             "filing_status": {
                 "file": filing_status_file,
@@ -374,6 +351,21 @@ if __name__ == "__main__":
                 "accessor": "general info"
             }
         }
+
+        for pdf_field in mapping_dict.values():
+            pdf_field["writer"].writeheader()
+
+        filer_writer.writeheader()
+        filing_writer.writeheader()
+        employer_writer.writeheader()
+        spouse_employer_writer.writeheader()
+
+        employer_field_corrector = levenshtein_distance.SpellingCorrector(
+            employer_writer.fieldnames
+        )
+        spouse_employer_field_corrector = levenshtein_distance.SpellingCorrector(
+            spouse_employer_writer.fieldnames
+        )
 
         scraper = FinancialDisclosureScraper()
         for filer in scraper.scrape():

--- a/scrapers/financial_disclosure/scrape_financial_disclosures.py
+++ b/scrapers/financial_disclosure/scrape_financial_disclosures.py
@@ -96,6 +96,17 @@ if __name__ == "__main__":
         open("data/intermediate/employer.csv", "w") as employer_file,
         open("data/intermediate/spouse_employer.csv", "w") as spouse_employer_file,
         open("data/intermediate/filing_status.csv", "w") as filing_status_file,
+        open("data/intermediate/income.csv", "w") as income_file,
+        open("data/intermediate/specializations.csv", "w") as specializations_file,
+        open("data/intermediate/consulting.csv", "w") as consulting_file,
+        open("data/intermediate/real_estate.csv", "w") as real_estate_file,
+        open("data/intermediate/business.csv", "w") as business_file,
+        open("data/intermediate/membership.csv", "w") as membership_file,
+        open("data/intermediate/licenses.csv", "w") as licenses_file,
+        open("data/intermediate/provisions.csv", "w") as provisions_file,
+        open("data/intermediate/representation.csv", "w") as representation_file,
+        open("data/intermediate/general.csv", "w") as general_file,
+
     ):
         filer_writer = csv.DictWriter(
             filer_file,
@@ -166,11 +177,104 @@ if __name__ == "__main__":
                 "ReportID"
             ],
         )
+        income_writer = csv.DictWriter(
+            income_file,
+            [
+                "Income source (*see pg. 4):",
+                "Received by (list the name of the reporting individual or spouse):",
+                "ReportID"
+            ],
+        )
+        specializations_writer = csv.DictWriter(
+            specializations_file,
+            [
+                "Describe the major areas of specialization or sources of income.",
+                "Received by (list the name of the reporting individual or spouse):",
+                "ReportID"
+            ],
+        )
+        consulting_writer = csv.DictWriter(
+            consulting_file,
+            [
+                "Client name & address:",
+                "Represented by: List the name of the reporting individual’s firm or spouse’s firm",
+                "ReportID"
+            ],
+        )
+        real_estate_writer = csv.DictWriter(
+            real_estate_file,
+            [
+                "Owner",
+                "County",
+                "General Description",
+                "ReportID"
+            ],
+        )
+        business_writer = csv.DictWriter(
+            business_file,
+            [
+                "Name of business:",
+                "Position held:",
+                "General statement of business purpose:",
+                "Received by (list the name of the reporting individual or spouse):",
+                "ReportID"
+            ],
+        )
+        membership_writer = csv.DictWriter(
+            membership_file,
+            [
+                "Name of business:",
+                "Board member (list the name of the reporting individual or spouse):",
+                "ReportID"
+            ],
+        )
+        licenses_writer = csv.DictWriter(
+            licenses_file,
+            [
+                "Type of license:",
+                "Individual holding license (list the name of the reporting individual or spouse):",
+                "ReportID"
+            ],
+        )
+        provisions_writer = csv.DictWriter(
+            provisions_file,
+            [
+                "State agency to which goods and/or services were provided:",
+                "Individual providing goods or services (list the name of the reporting individual or spouse):",
+                "ReportID"
+            ],
+        )
+        representation_writer = csv.DictWriter(
+            representation_file,
+            [
+                "State agency (other than a court):",
+                "Individual assisting client (list the name of the reporting individual or spouse):",
+                "ReportID"
+            ],
+        )
+        general_writer = csv.DictWriter(
+            general_file,
+            [
+                "Input",
+                "ReportID"
+            ],
+        )
+
         filer_writer.writeheader()
         filing_writer.writeheader()
         employer_writer.writeheader()
         spouse_employer_writer.writeheader()
         filing_status_writer.writeheader()
+        income_writer.writeheader()
+        specializations_writer.writeheader()
+        consulting_writer.writeheader()
+        real_estate_writer.writeheader()
+        business_writer.writeheader()
+        membership_writer.writeheader()
+        licenses_writer.writeheader()
+        provisions_writer.writeheader()
+        representation_writer.writeheader()
+        general_writer.writeheader()
 
         employer_field_corrector = levenshtein_distance.SpellingCorrector(
             employer_writer.fieldnames
@@ -178,9 +282,98 @@ if __name__ == "__main__":
         spouse_employer_field_corrector = levenshtein_distance.SpellingCorrector(
             spouse_employer_writer.fieldnames
         )
-        filing_status_field_corrector = levenshtein_distance.SpellingCorrector(
-            filing_status_writer.fieldnames
-        )
+
+        # pdf fields that return lists of dicts w/ identical keys
+        mapping_dict = {
+            "filing_status": {
+                "file": filing_status_file,
+                "writer": filing_status_writer,
+                "corrector": levenshtein_distance.SpellingCorrector(
+                    filing_status_writer.fieldnames
+                ),
+                "accessor": "current filing status",
+            },
+            "income": {
+                "file": income_file,
+                "writer": income_writer,
+                "corrector": levenshtein_distance.SpellingCorrector(
+                    income_writer.fieldnames
+                ),
+                "accessor": "income sources",
+            },
+            "specializations": {
+                "file": specializations_file,
+                "writer": specializations_writer,
+                "corrector": levenshtein_distance.SpellingCorrector(
+                    specializations_writer.fieldnames
+                ),
+                "accessor": "specializations",
+            },
+            "consulting": {
+                "file": consulting_file,
+                "writer": consulting_writer,
+                "corrector": levenshtein_distance.SpellingCorrector(
+                    consulting_writer.fieldnames
+                ),
+                "accessor": "consulting or lobbying",
+            },
+            "real_estate": {
+                "file": real_estate_file,
+                "writer": real_estate_writer,
+                "corrector": levenshtein_distance.SpellingCorrector(
+                    real_estate_writer.fieldnames
+                ),
+                "accessor": "real estate",
+            },
+            "business": {
+                "file": business_file,
+                "writer": business_writer,
+                "corrector": levenshtein_distance.SpellingCorrector(
+                    business_writer.fieldnames
+                ),
+                "accessor": "other business",
+            },
+            "membership": {
+                "file": membership_file,
+                "writer": membership_writer,
+                "corrector": levenshtein_distance.SpellingCorrector(
+                    membership_writer.fieldnames
+                ),
+                "accessor": "board membership",
+            },
+            "licenses": {
+                "file": licenses_file,
+                "writer": licenses_writer,
+                "corrector": levenshtein_distance.SpellingCorrector(
+                    licenses_writer.fieldnames
+                ),
+                "accessor": "professional licenses",
+            },
+            "provisions": {
+                "file": provisions_file,
+                "writer": provisions_writer,
+                "corrector": levenshtein_distance.SpellingCorrector(
+                    provisions_writer.fieldnames
+                ),
+                "accessor": "provisions to state agencies",
+            },
+            "representation": {
+                "file": representation_file,
+                "writer": representation_writer,
+                "corrector": levenshtein_distance.SpellingCorrector(
+                    representation_writer.fieldnames
+                ),
+                "accessor": "state agency representation",
+            },
+            "general": {
+                "file": general_file,
+                "writer": general_writer,
+                "corrector": levenshtein_distance.SpellingCorrector(
+                    general_writer.fieldnames
+                ),
+                "accessor": "general info"
+            }
+        }
 
         scraper = FinancialDisclosureScraper()
         for filer in scraper.scrape():
@@ -211,9 +404,14 @@ if __name__ == "__main__":
                     spouse_employer_data | {"ReportID": report_id}
                 )
 
-                for entry in extracted_info["current filing status"]:
-                    filing_status_data = {
-                        filing_status_field_corrector.correct(k): v
-                        for k, v in entry.items()
-                    }
-                    filing_status_writer.writerow(filing_status_data | {"ReportID": report_id})
+                for pdf_field in mapping_dict.values():
+                    accessor = pdf_field["accessor"]
+                    corrector = pdf_field["corrector"]
+                    writer = pdf_field["writer"]
+
+                    for entry in extracted_info[accessor]:
+                        field_data = {
+                            corrector.correct(k): v
+                            for k, v in entry.items()
+                        }
+                        writer.writerow(field_data | {"ReportID": report_id})


### PR DESCRIPTION
## Overview

This prevents a TypeError that occurs when iterating through a page with no tables.

I realized this solution was the same as #18,  just without the extra table settings to join separated tables. So I borrowed the list comprehension from that.
