### PR TITLE
Lobbyist employer scraper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-include lobbyists.mk disclosures.mk candidates.mk
+include lobbyists.mk disclosures.mk candidates.mk independent_expenditures.mk
 
 .PHONY : all upload-to-s3 clean
 
@@ -6,13 +6,15 @@ all : data/processed/disclosures.xlsx			\
       data/processed/candidate_committees.csv		\
       data/processed/candidate_committee_filings.csv	\
       data/processed/pac_committees.csv			\
-      data/processed/pac_committee_filings.csv
+      data/processed/pac_committee_filings.csv		\
+      data/processed/independent_expenditures.csv
 
 upload-to-s3 : data/processed/disclosures.xlsx			\
                data/processed/candidate_committees.csv		\
                data/processed/candidate_committee_filings.csv	\
                data/processed/pac_committees.csv		\
-               data/processed/pac_committee_filings.csv
+               data/processed/pac_committee_filings.csv  \
+               data/processed/independent_expenditures.csv
 
 	for file in $^; do aws s3 cp $$file $(S3BUCKET) --acl public-read; done
 

--- a/independent_expenditures.mk
+++ b/independent_expenditures.mk
@@ -1,0 +1,5 @@
+.PHONY: independent_expenditures
+independent_expenditures : data/processed/independent_expenditures.csv
+
+data/processed/independent_expenditures.csv :
+	python -m scrapers.financial_disclosure.scrape_independent_expenditures > $@

--- a/lobbyists.mk
+++ b/lobbyists.mk
@@ -62,8 +62,7 @@ data/intermediate/clients.csv : data/raw/clients.csv
 
 # Concatenate individual lobbyist and lobbyist employer filings
 data/intermediate/filings.csv : data/intermediate/employer_filings.csv data/intermediate/individual_filings.csv
-	tail -n +2 data/intermediate/individual_filings.csv > data/intermediate/individual_filings_rows.csv; \
-	cat data/intermediate/employer_filings.csv data/intermediate/individual_filings_rows.csv > $@
+	csvstack $^ > $@
 
 data/intermediate/individual_filings.csv : data/raw/lobbyists.csv
 	csvsql --query "SELECT DISTINCT MemberID AS id, MemberVersionID AS version FROM STDIN" < $< | \

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ awscli
 csvkit
 pyOpenSSL>=23.3.0 
 pandas
+click

--- a/scrapers/financial_disclosure/scrape_independent_expenditures.py
+++ b/scrapers/financial_disclosure/scrape_independent_expenditures.py
@@ -1,0 +1,164 @@
+import csv
+import json
+import logging
+import scrapelib
+import sys
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
+
+class IndependentExpenditureScraper(scrapelib.Scraper):
+    election_years = ("2021", "2022", "2023", "2024")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def _get_donor_details(self, transaction_id):
+        donor_details_resp = self.get(
+            "https://login.cfis.sos.state.nm.us/api/Public/"
+            f"GetIEDonors?transactionId={transaction_id}&transactionVersId=1"
+        )
+
+        if not donor_details_resp.ok:
+            return None
+
+        donor_details = donor_details_resp.json()
+        if not donor_details:
+            return [
+                {
+                    "DonorName": None,
+                    "DonorAmount": None,
+                    "DonorAddress": None,
+                }
+            ]
+
+        return [
+            {
+                "DonorName": donor["DonorName"],
+                "DonorAmount": donor["DonatedAmount"],
+                "DonorAddress": donor["Donor"]["Address"]["CompleteAddress"],
+            }
+            for donor in donor_details
+        ]
+
+    def _expenditures(self, year):
+        payload = {
+            "TransactionType": "IE",
+            "CommitteeType": None,
+            "ElectionYear": year,
+            "CommitteeName": None,
+            "TransactionCategoryCode": None,
+            "AmountType": None,
+            "ContributorPayeeName": None,
+            "TransactionBeginDate": None,
+            "TransactionEndDate": None,
+            "ValidationRequired": 0,
+            "pageNumber": 1,
+            "pageSize": 1000,
+            "sortDir": "asc",
+            "sortedBy": "",
+            "TransactionAmount": None,
+            "TransactionUnderAmount": None,
+            "pacType": "",
+            "Occupation": None,
+            "StateCode": None,
+            "city": None,
+            "Zipcode": None,
+            "ZipExt": None,
+            "Reason": None,
+            "Stance": "",
+        }
+
+        page_number = 1
+        page_size = 1000
+        result_count = 1000
+
+        while result_count == page_size:
+            logger.debug(f"Fetching page {page_number} for {year}")
+
+            _payload = payload.copy()
+            _payload.update({"PageNo": page_number})
+
+            logger.debug(_payload)
+
+            response = self.post(
+                "https://login.cfis.sos.state.nm.us/api///"
+                "Search/TransactionSearchInformation",
+                data=json.dumps(_payload),
+                headers={"Content-Type": "application/json"},
+                verify=False,
+            )
+
+            if response.ok:
+                results = response.json()
+
+                yield from results
+
+                result_count = len(results)
+
+                logger.debug(f"Last page {page_number} had {result_count} results")
+
+                page_number += 1
+            else:
+                logger.error(
+                    f"Failed to fetch results:\n{response.content.decode('utf-8')}"
+                )
+                sys.exit()
+
+    def scrape(self):
+        for year in IndependentExpenditureScraper.election_years:
+            for result in self._expenditures(year):
+                transaction_id = result["TransactionId"]
+
+                donors = self._get_donor_details(transaction_id)
+                for donor in donors:
+                    yield {
+                        "ReportingEntityName": result["Name"],
+                        "ReportingEntityType": result["CommitteeType"],
+                        "Payee": result["ContributorPayeeName"],
+                        "PayeeType": result["EntityTypeDescription"],
+                        "PayeeAddress": result["Address"],
+                        "TransactionDate": result["TransactionDate"],
+                        "ExpenditureAmount": result["Amount"],
+                        "ExpenditureDescription": result[
+                            "TransactionPurposeDescription"
+                        ],
+                        "ElectionYear": result["ElectionYear"],
+                        "ElectionType": result["ElectionPeriod"],
+                        "Reason": result["Reason"],
+                        "Stance": result["Stance"],
+                        **donor,
+                    }
+
+
+if __name__ == "__main__":
+    writer = csv.DictWriter(
+        sys.stdout,
+        fieldnames=[
+            "TransactionDate",
+            "ReportingEntityName",
+            "ReportingEntityType",
+            "Payee",
+            "PayeeType",
+            "PayeeAddress",
+            "ExpenditureAmount",
+            "ExpenditureDescription",
+            "ElectionType",
+            "ElectionYear",
+            "Reason",
+            "Stance",
+            "DonorName",
+            "DonorAddress",
+            "DonorAmount",
+        ],
+        extrasaction="ignore",
+    )
+
+    writer.writeheader()
+
+    scraper = IndependentExpenditureScraper(
+        requests_per_minute=60, retry_attempts=3, verify=False
+    )
+    for result in scraper.scrape():
+        writer.writerow(result)

--- a/scrapers/lobbyist/scrape_employers.py
+++ b/scrapers/lobbyist/scrape_employers.py
@@ -1,0 +1,91 @@
+import csv
+import json
+import logging
+import scrapelib
+import sys
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
+
+class LobbyistEmployerScraper(scrapelib.Scraper):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def _employers(self):
+        payload = {
+            "FilerType": "CR",
+            "ExpenditureType": None,
+            "ElectionYear": "",
+            "AmountType": "Over",
+            "pageNumber": 1,
+            "pageSize": 1000,
+            "sortDir": "ASC",
+            "sortedBy": "",
+        }
+
+        page_number = 1
+        page_size = 1000
+        result_count = 1000
+
+        while result_count == page_size:
+            logger.debug(f"Fetching page {page_number}")
+
+            _payload = {**payload, "pageNumber": page_number}
+            logger.debug(_payload)
+
+            response = self.post(
+                "https://login.cfis.sos.state.nm.us/api///"
+                "Search/LobbyistExpenditureSearchInformation",
+                data=json.dumps(_payload),
+                headers={"Content-Type": "application/json"},
+                verify=False,
+            )
+
+            if response.ok:
+                results = response.json()
+
+                yield from results
+
+                result_count = len(results)
+
+                logger.debug(f"Last page {page_number} had {result_count} results")
+
+                page_number += 1
+            else:
+                logger.error(
+                    f"Failed to fetch results:\n{response.content.decode('utf-8')}"
+                )
+                sys.exit()
+
+    def scrape(self):
+        for result in self._employers():
+            yield {
+                "Name": result["Name"],
+                "LobbyMemberID": result["LobbyMemberID"],
+                "LobbyMemberversionid": result["LobbyMemberversionid"],
+            }
+
+
+def main():
+    writer = csv.DictWriter(
+        sys.stdout,
+        fieldnames=[
+            "Name",
+            "LobbyMemberID",
+            "LobbyMemberversionid",
+        ],
+        extrasaction="ignore",
+    )
+
+    writer.writeheader()
+
+    scraper = LobbyistEmployerScraper(
+        requests_per_minute=60, retry_attempts=3, verify=False
+    )
+    for result in scraper.scrape():
+        writer.writerow(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/scrapers/lobbyist/scrape_filings.py
+++ b/scrapers/lobbyist/scrape_filings.py
@@ -18,15 +18,20 @@ class LobbyistScraper(ABC, scrapelib.Scraper):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+    @property
+    @abstractmethod
+    def url(self):
+        pass
+
     @abstractmethod
     def _get_payload(self, id, version):
         pass
 
-    def scrape(self, url, id, version):
+    def scrape(self, id, version):
         payload = self._get_payload(id, version)
 
         response = self.post(
-            url,
+            self.url,
             data=json.dumps(payload),
             headers={"Content-Type": "application/json"},
             verify=False,
@@ -40,7 +45,9 @@ class LobbyistScraper(ABC, scrapelib.Scraper):
 
 
 class LobbyistEmployerScraper(LobbyistScraper):
-    url = "https://login.cfis.sos.state.nm.us/api//ExploreClients/Disclosures"
+    @property
+    def url(self):
+        return "https://login.cfis.sos.state.nm.us/api//ExploreClients/Disclosures"
 
     def _get_payload(self, id, version):
         return {
@@ -53,12 +60,11 @@ class LobbyistEmployerScraper(LobbyistScraper):
             "ClientVersionID": version,
         }
 
-    def scrape(self, id, version):
-        return super().scrape(self.__class__.url, id, version)
-
 
 class IndividualLobbyistScraper(LobbyistScraper):
-    url = "https://login.cfis.sos.state.nm.us/api//ExploreClients/Fillings"
+    @property
+    def url(self):
+        return "https://login.cfis.sos.state.nm.us/api//ExploreClients/Fillings"
 
     def _get_payload(self, id, version):
         return {
@@ -70,9 +76,6 @@ class IndividualLobbyistScraper(LobbyistScraper):
             "LobbyistID": id,
             "LobbyistVersionID": version,
         }
-
-    def scrape(self, id, version):
-        return super().scrape(self.__class__.url, id, version)
 
 
 @click.command()

--- a/scrapers/lobbyist/scrape_filings.py
+++ b/scrapers/lobbyist/scrape_filings.py
@@ -1,8 +1,11 @@
+from abc import ABC, abstractmethod
+
 import csv
 import json
 import logging
 import scrapelib
 import sys
+import click
 
 from tqdm import tqdm
 
@@ -10,70 +13,127 @@ from tqdm import tqdm
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-reader = csv.DictReader(sys.stdin)
-writer = csv.DictWriter(
-    sys.stdout,
-    fieldnames=[
-        "ClientID",
-        "ReportName",
-        "ReportFileName",
-        "ReportTypeCode",
-        "ReportType",
-        "PeriodStart",
-        "PeriodEnd",
-        "DueDate",
-        "SubmittedDate",
-        "TotalRows",
-        "ReportID",
-        "ReportVersionID",
-        "Status",
-        "IncidentalLobbying",
-        "ReportStatus",
-        "IsAfterDueDate",
-        "CreatedBy",
-        "CreatedDate",
-        "CreatedIPAddress",
-        "LobbyistClientID",
-        "LobbyistClientVersionID",
-        "LastModifiedBy",
-        "LastModifiedDate",
-        "LastModifiedIPAddress",
-        "Message",
-        "IsSuccess",
-        "Action",
-        "IsDirty",
-        "PersonID",
-        "PersonVersionID",
-        "MemberID",
-    ],
-)
 
-writer.writeheader()
+class LobbyistScraper(ABC, scrapelib.Scraper):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
-s = scrapelib.Scraper(requests_per_minute=0, retry_attempts=3, verify=False)
+    @abstractmethod
+    def _get_payload(self, id, version):
+        pass
 
-payload = {
-    "PageNo": 1,
-    "PageSize": 1000,
-    "SortDir": "ASC",
-    "SortedBy": "",
-    "ElectionYear": "",
-    "LobbyistVersionID": "",
-}
+    def scrape(self, url, id, version):
+        payload = self._get_payload(id, version)
 
-for row in tqdm(reader):
-    _payload = payload.copy()
-    _payload["LobbyistID"] = row["MemberID"]
-    _payload["LobbyistVersionID"] = row["MemberVersionID"]
+        response = self.post(
+            url,
+            data=json.dumps(payload),
+            headers={"Content-Type": "application/json"},
+            verify=False,
+        )
 
-    response = s.post(
-        "https://login.cfis.sos.state.nm.us/api//ExploreClients/Fillings",
-        data=json.dumps(_payload),
-        headers={"Content-Type": "application/json"},
+        if response.ok:
+            for record in response.json():
+                # Add the lobbyist ID and version to the filing record
+                record["MemberID"] = id
+                return record
+
+
+class LobbyistEmployerScraper(LobbyistScraper):
+    url = "https://login.cfis.sos.state.nm.us/api//ExploreClients/Disclosures"
+
+    def _get_payload(self, id, version):
+        return {
+            "PageNumber": 1,
+            "PageSize": 1000,
+            "SortDir": "ASC",
+            "SortedBy": "",
+            "Year": "",
+            "ClientID": id,
+            "ClientVersionID": version,
+        }
+
+    def scrape(self, id, version):
+        return super().scrape(self.__class__.url, id, version)
+
+
+class IndividualLobbyistScraper(LobbyistScraper):
+    url = "https://login.cfis.sos.state.nm.us/api//ExploreClients/Fillings"
+
+    def _get_payload(self, id, version):
+        return {
+            "PageNo": 1,
+            "PageSize": 1000,
+            "SortDir": "ASC",
+            "SortedBy": "",
+            "ElectionYear": "",
+            "LobbyistID": id,
+            "LobbyistVersionID": version,
+        }
+
+    def scrape(self, id, version):
+        return super().scrape(self.__class__.url, id, version)
+
+
+@click.command()
+@click.option("--employer", "is_employer_scrape", is_flag=True)
+def main(is_employer_scrape):
+
+    scraper_opts = {"requests_per_minute": 60, "retry_attempts": 3, "verify": False}
+
+    if is_employer_scrape:
+        scraper = LobbyistEmployerScraper(**scraper_opts)
+    else:
+        scraper = IndividualLobbyistScraper(**scraper_opts)
+
+    reader = csv.DictReader(sys.stdin)
+
+    writer = csv.DictWriter(
+        sys.stdout,
+        fieldnames=[
+            "ClientID",
+            "ReportName",
+            "ReportFileName",
+            "ReportTypeCode",
+            "ReportType",
+            "PeriodStart",
+            "PeriodEnd",
+            "DueDate",
+            "SubmittedDate",
+            "TotalRows",
+            "ReportID",
+            "ReportVersionID",
+            "Status",
+            "IncidentalLobbying",
+            "ReportStatus",
+            "IsAfterDueDate",
+            "CreatedBy",
+            "CreatedDate",
+            "CreatedIPAddress",
+            "LobbyistClientID",
+            "LobbyistClientVersionID",
+            "LastModifiedBy",
+            "LastModifiedDate",
+            "LastModifiedIPAddress",
+            "Message",
+            "IsSuccess",
+            "Action",
+            "IsDirty",
+            "PersonID",
+            "PersonVersionID",
+            "MemberID",
+        ],
     )
 
-    if response.ok:
-        for record in response.json():
-            # Add the lobbyist ID and version to the filing record
-            record["MemberID"] = row["MemberID"]
-            writer.writerow(record)
+    writer.writeheader()
+
+    for row in tqdm(reader):
+        logger.debug(row)
+        id, version = row["id"], str(int(float(row["version"])))
+        result = scraper.scrape(id, version)
+        if result:
+            writer.writerow(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Overview

This PR adds a lobbyist employer scraper to the existing lobbyist scraper in `scrapers/lobbyist/scrape_filings.py`. The after scraping both individual lobbyist filings and lobbyist employer filings, the pipeline is unchanged.

Depends on #30 

Closes #29 

## Testing

Run `make data/processed/lobbyist_expenditures.csv`