### PR TITLE
Zip lobbyist data into a workbook

### DIFF
--- a/.github/workflows/tmp.yml
+++ b/.github/workflows/tmp.yml
@@ -1,0 +1,33 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Run lobbyist scrape
+
+
+# Controls when the action will run. 
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - name: setup requirementss
+        run: pip install -r requirements.txt
+      - name: scrape lobbyist data
+        run: make data/processed/lobbyist.xlsx data/processed/lobbyist_employer.xlsx
+      - name: upload to s3
+        env:
+          S3BUCKET: ${{ secrets.S3BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          aws s3 cp data/processed/lobbyist.xlsx $(S3BUCKET) --acl public-read
+          aws s3 cp data/processed/lobbyist_employer.xlsx $(S3BUCKET) --acl public-read

--- a/.github/workflows/tmp.yml
+++ b/.github/workflows/tmp.yml
@@ -27,5 +27,5 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          aws s3 cp data/processed/lobbyist.xlsx $(S3BUCKET) --acl public-read
-          aws s3 cp data/processed/lobbyist_employer.xlsx $(S3BUCKET) --acl public-read
+          aws s3 cp data/processed/lobbyist.xlsx $S3BUCKET --acl public-read
+          aws s3 cp data/processed/lobbyist_employer.xlsx $S3BUCKET --acl public-read

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ cython_debug/
 data/lobbyist*
 data/*/*
 !data/*/.gitkeep
+empty_*.csv

--- a/.gitignore
+++ b/.gitignore
@@ -159,5 +159,6 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 .DS_Store
+data/lobbyist*
 data/*/*
 !data/*/.gitkeep

--- a/Makefile
+++ b/Makefile
@@ -7,17 +7,15 @@ all : data/processed/disclosures.xlsx			\
       data/processed/candidate_committee_filings.csv	\
       data/processed/pac_committees.csv			\
       data/processed/pac_committee_filings.csv		\
-      data/intermediate/lobbyists.csv     \
-      data/processed/lobbyist_employer.csv    \
+      data/processed/lobbyists.xlsx                   \
       data/processed/independent_expenditures.xlsx
 
-upload-to-s3 : data/processed/disclosures.xlsx			\
+upload-to-s3 : data/processed/disclosures.xlsx			      \
                data/processed/candidate_committees.csv		\
                data/processed/candidate_committee_filings.csv	\
-               data/processed/pac_committees.csv		\
-               data/processed/pac_committee_filings.csv  \
-               data/intermediate/lobbyists.csv     \
-               data/processed/lobbyist_employer.csv    \
+               data/processed/pac_committees.csv		      \
+               data/processed/pac_committee_filings.csv           \
+               data/processed/lobbyists.xlsx                      \
                data/processed/independent_expenditures.xlsx
 
 	for file in $^; do aws s3 cp $$file $(S3BUCKET) --acl public-read; done

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,31 @@
-include lobbyists.mk disclosures.mk candidates.mk independent_expenditures.mk
-
 .PHONY : all upload-to-s3 clean
 
 all : data/processed/disclosures.xlsx			\
-      data/processed/candidate_committees.csv		\
-      data/processed/candidate_committee_filings.csv	\
-      data/processed/pac_committees.csv			\
-      data/processed/pac_committee_filings.csv		\
-      data/processed/lobbyists.xlsx                   \
-      data/processed/independent_expenditures.xlsx
+	data/processed/candidate_committees.csv		\
+	data/processed/candidate_committee_filings.csv	\
+	data/processed/pac_committees.csv			\
+	data/processed/pac_committee_filings.csv		\
+	data/processed/lobbyists.xlsx                   \
+	data/processed/independent_expenditures.xlsx
 
 upload-to-s3 : data/processed/disclosures.xlsx			      \
-               data/processed/candidate_committees.csv		\
-               data/processed/candidate_committee_filings.csv	\
-               data/processed/pac_committees.csv		      \
-               data/processed/pac_committee_filings.csv           \
-               data/processed/lobbyists.xlsx                      \
-               data/processed/independent_expenditures.xlsx
+		   data/processed/candidate_committees.csv		\
+		   data/processed/candidate_committee_filings.csv	\
+		   data/processed/pac_committees.csv		      \
+		   data/processed/pac_committee_filings.csv           \
+		   data/processed/lobbyists.xlsx                      \
+		   data/processed/independent_expenditures.xlsx
 
 	for file in $^; do aws s3 cp $$file $(S3BUCKET) --acl public-read; done
 
-clean :
-	rm data/intermediate/*
+%_data_dirs :
+	mkdir -p $(patsubst %,data/$*/%,raw intermediate processed assets)
 
+clean :
+	rm -rf data/raw/* data/intermediate/*
+
+include lobbyists.mk \
+	lobbyist_employer.mk \
+	disclosures.mk \
+	candidates.mk \
+	independent_expenditures.mk

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,27 @@
 .PHONY : all upload-to-s3 clean
 
-all : data/processed/disclosures.xlsx			\
-	data/processed/candidate_committees.csv		\
-	data/processed/candidate_committee_filings.csv	\
-	data/processed/pac_committees.csv			\
-	data/processed/pac_committee_filings.csv		\
-	data/processed/lobbyists.xlsx                   \
+all : data/processed/disclosures.xlsx \
+	data/processed/candidate_committees.csv	\
+	data/processed/candidate_committee_filings.csv \
+	data/processed/pac_committees.csv \
+	data/processed/pac_committee_filings.csv \
+	data/processed/lobbyist.xlsx \
+	data/processed/lobbyist_employer.xlsx \
 	data/processed/independent_expenditures.xlsx
 
-upload-to-s3 : data/processed/disclosures.xlsx			      \
-		   data/processed/candidate_committees.csv		\
-		   data/processed/candidate_committee_filings.csv	\
-		   data/processed/pac_committees.csv		      \
-		   data/processed/pac_committee_filings.csv           \
-		   data/processed/lobbyists.xlsx                      \
+upload-to-s3 : data/processed/disclosures.xlsx \
+		   data/processed/candidate_committees.csv \
+		   data/processed/candidate_committee_filings.csv \
+		   data/processed/pac_committees.csv \
+		   data/processed/pac_committee_filings.csv \
+		   data/processed/lobbyist.xlsx \
+		   data/processed/lobbyist_employer.xlsx \
 		   data/processed/independent_expenditures.xlsx
 
 	for file in $^; do aws s3 cp $$file $(S3BUCKET) --acl public-read; done
 
 %_data_dirs :
 	mkdir -p $(patsubst %,data/$*/%,raw intermediate processed assets)
-
-clean :
-	rm -rf data/raw/* data/intermediate/*
 
 include lobbyists.mk \
 	lobbyist_employer.mk \

--- a/lobbyist_employer.mk
+++ b/lobbyist_employer.mk
@@ -24,7 +24,6 @@ lobbyist_employer_filings : $(DATA_DIR)/intermediate/lobbyist_employer_filings.c
 
 $(DATA_DIR)/intermediate/lobbyist_employer_filings.csv : $(DATA_DIR)/raw/lobbyist_employer.csv
 	csvsql --query "SELECT DISTINCT LobbyMemberID AS id, LobbyMemberversionid AS version FROM STDIN" < $< | \
-	head -n 25 | \
 	python -m scrapers.lobbyist.scrape_filings --employer > $@
 
 $(DATA_DIR)/intermediate/lobbyist_employer.csv : $(DATA_DIR)/raw/lobbyist_employer.csv

--- a/lobbyist_employer.mk
+++ b/lobbyist_employer.mk
@@ -24,7 +24,8 @@ lobbyist_employer_filings : $(LOBBYIST_EMPLOYER_DATA_DIR)/intermediate/lobbyist_
 
 $(LOBBYIST_EMPLOYER_DATA_DIR)/intermediate/lobbyist_employer_filings.csv : $(LOBBYIST_EMPLOYER_DATA_DIR)/raw/lobbyist_employer.csv
 	csvsql --query "SELECT DISTINCT LobbyMemberID AS id, LobbyMemberversionid AS version FROM STDIN" < $< | \
-	python -m scrapers.lobbyist.scrape_filings --employer > $@
+	python -m scrapers.lobbyist.scrape_filings --employer | \
+	csvsql --query 'select ReportFileName, ReportTypeCode, MAX(MemberID) as MemberID from STDIN group by ReportFileName, ReportTypeCode' > $@
 
 $(LOBBYIST_EMPLOYER_DATA_DIR)/intermediate/lobbyist_employer.csv : $(LOBBYIST_EMPLOYER_DATA_DIR)/raw/lobbyist_employer.csv
 	csvsql --query "SELECT DISTINCT \

--- a/lobbyist_employer.mk
+++ b/lobbyist_employer.mk
@@ -1,0 +1,45 @@
+# Lobbyist expenditures and contributions
+DATA_DIR=data/lobbyist_employer
+
+.PRECIOUS : $(DATA_DIR)/raw/lobbyist_employer.csv \
+	$(DATA_DIR)/intermediate/lobbyist_employer_contributions.csv \
+	$(DATA_DIR)/intermediate/lobbyist_employer_expenditures.csv
+
+$(DATA_DIR)/processed/lobbyist_employer.xlsx : $(DATA_DIR)/intermediate/lobbyist_employer.csv      \
+								$(DATA_DIR)/processed/lobbyist_employer_contributions.csv \
+								$(DATA_DIR)/processed/lobbyist_employer_expenditures.csv
+	python scripts/to_excel.py $^ $@
+
+$(DATA_DIR)/processed/lobbyist_employer_%.csv : $(DATA_DIR)/intermediate/lobbyist_employer_%.csv \
+	$(DATA_DIR)/intermediate/lobbyist_employer_filings.csv \
+	$(DATA_DIR)/intermediate/lobbyist_employer.csv
+	csvjoin --left -c Source,ReportFileName $< $(word 2, $^) | \
+	csvjoin --left -c MemberID,LobbyMemberID - $(word 3, $^) > $@
+
+$(DATA_DIR)/intermediate/lobbyist_employer_%.csv : lobbyist_employer_filings
+	python -m scrapers.lobbyist.extract_transactions $* $(DATA_DIR) > $@
+
+lobbyist_employer_filings : $(DATA_DIR)/intermediate/lobbyist_employer_filings.csv
+	python -m scrapers.lobbyist.download_filings $(DATA_DIR) < $<
+
+$(DATA_DIR)/intermediate/lobbyist_employer_filings.csv : $(DATA_DIR)/raw/lobbyist_employer.csv
+	csvsql --query "SELECT DISTINCT LobbyMemberID AS id, LobbyMemberversionid AS version FROM STDIN" < $< | \
+	head -n 25 | \
+	python -m scrapers.lobbyist.scrape_filings --employer > $@
+
+$(DATA_DIR)/intermediate/lobbyist_employer.csv : $(DATA_DIR)/raw/lobbyist_employer.csv
+	csvsql --query "SELECT DISTINCT \
+		LobbyMemberID,  \
+		Name \
+	FROM ( \
+		SELECT \
+			LobbyMemberID, \
+			MAX(LobbyMemberversionid) AS LobbyMemberversionid \
+		FROM STDIN \
+		GROUP BY LobbyMemberID \
+	) AS lobbyists \
+	JOIN STDIN \
+	USING (LobbyMemberID, LobbyMemberversionid)" < $< > $@
+
+$(DATA_DIR)/raw/lobbyist_employer.csv : lobbyist_employer_data_dirs
+	python -m scrapers.lobbyist.scrape_employers > $@

--- a/lobbyist_employer.mk
+++ b/lobbyist_employer.mk
@@ -1,32 +1,32 @@
 # Lobbyist expenditures and contributions
-DATA_DIR=data/lobbyist_employer
+LOBBYIST_EMPLOYER_DATA_DIR=data/lobbyist_employer
 
-.PRECIOUS : $(DATA_DIR)/raw/lobbyist_employer.csv \
-	$(DATA_DIR)/intermediate/lobbyist_employer_contributions.csv \
-	$(DATA_DIR)/intermediate/lobbyist_employer_expenditures.csv
+.PRECIOUS : $(LOBBYIST_EMPLOYER_DATA_DIR)/raw/lobbyist_employer.csv \
+	$(LOBBYIST_EMPLOYER_DATA_DIR)/intermediate/lobbyist_employer_contributions.csv \
+	$(LOBBYIST_EMPLOYER_DATA_DIR)/intermediate/lobbyist_employer_expenditures.csv
 
-$(DATA_DIR)/processed/lobbyist_employer.xlsx : $(DATA_DIR)/intermediate/lobbyist_employer.csv      \
-								$(DATA_DIR)/processed/lobbyist_employer_contributions.csv \
-								$(DATA_DIR)/processed/lobbyist_employer_expenditures.csv
+$(LOBBYIST_EMPLOYER_DATA_DIR)/processed/lobbyist_employer.xlsx : $(LOBBYIST_EMPLOYER_DATA_DIR)/intermediate/lobbyist_employer.csv      \
+								$(LOBBYIST_EMPLOYER_DATA_DIR)/processed/lobbyist_employer_contributions.csv \
+								$(LOBBYIST_EMPLOYER_DATA_DIR)/processed/lobbyist_employer_expenditures.csv
 	python scripts/to_excel.py $^ $@
 
-$(DATA_DIR)/processed/lobbyist_employer_%.csv : $(DATA_DIR)/intermediate/lobbyist_employer_%.csv \
-	$(DATA_DIR)/intermediate/lobbyist_employer_filings.csv \
-	$(DATA_DIR)/intermediate/lobbyist_employer.csv
+$(LOBBYIST_EMPLOYER_DATA_DIR)/processed/lobbyist_employer_%.csv : $(LOBBYIST_EMPLOYER_DATA_DIR)/intermediate/lobbyist_employer_%.csv \
+	$(LOBBYIST_EMPLOYER_DATA_DIR)/intermediate/lobbyist_employer_filings.csv \
+	$(LOBBYIST_EMPLOYER_DATA_DIR)/intermediate/lobbyist_employer.csv
 	csvjoin --left -c Source,ReportFileName $< $(word 2, $^) | \
 	csvjoin --left -c MemberID,LobbyMemberID - $(word 3, $^) > $@
 
-$(DATA_DIR)/intermediate/lobbyist_employer_%.csv : lobbyist_employer_filings
-	python -m scrapers.lobbyist.extract_transactions $* $(DATA_DIR) > $@
+$(LOBBYIST_EMPLOYER_DATA_DIR)/intermediate/lobbyist_employer_%.csv : lobbyist_employer_filings
+	python -m scrapers.lobbyist.extract_transactions $* $(LOBBYIST_EMPLOYER_DATA_DIR) > $@
 
-lobbyist_employer_filings : $(DATA_DIR)/intermediate/lobbyist_employer_filings.csv
-	python -m scrapers.lobbyist.download_filings $(DATA_DIR) < $<
+lobbyist_employer_filings : $(LOBBYIST_EMPLOYER_DATA_DIR)/intermediate/lobbyist_employer_filings.csv
+	python -m scrapers.lobbyist.download_filings $(LOBBYIST_EMPLOYER_DATA_DIR) < $<
 
-$(DATA_DIR)/intermediate/lobbyist_employer_filings.csv : $(DATA_DIR)/raw/lobbyist_employer.csv
+$(LOBBYIST_EMPLOYER_DATA_DIR)/intermediate/lobbyist_employer_filings.csv : $(LOBBYIST_EMPLOYER_DATA_DIR)/raw/lobbyist_employer.csv
 	csvsql --query "SELECT DISTINCT LobbyMemberID AS id, LobbyMemberversionid AS version FROM STDIN" < $< | \
 	python -m scrapers.lobbyist.scrape_filings --employer > $@
 
-$(DATA_DIR)/intermediate/lobbyist_employer.csv : $(DATA_DIR)/raw/lobbyist_employer.csv
+$(LOBBYIST_EMPLOYER_DATA_DIR)/intermediate/lobbyist_employer.csv : $(LOBBYIST_EMPLOYER_DATA_DIR)/raw/lobbyist_employer.csv
 	csvsql --query "SELECT DISTINCT \
 		LobbyMemberID,  \
 		Name \
@@ -40,5 +40,5 @@ $(DATA_DIR)/intermediate/lobbyist_employer.csv : $(DATA_DIR)/raw/lobbyist_employ
 	JOIN STDIN \
 	USING (LobbyMemberID, LobbyMemberversionid)" < $< > $@
 
-$(DATA_DIR)/raw/lobbyist_employer.csv : lobbyist_employer_data_dirs
+$(LOBBYIST_EMPLOYER_DATA_DIR)/raw/lobbyist_employer.csv : lobbyist_employer_LOBBYIST_EMPLOYER_DATA_DIRs
 	python -m scrapers.lobbyist.scrape_employers > $@

--- a/lobbyist_employer.mk
+++ b/lobbyist_employer.mk
@@ -5,7 +5,7 @@ LOBBYIST_EMPLOYER_DATA_DIR=data/lobbyist_employer
 	$(LOBBYIST_EMPLOYER_DATA_DIR)/intermediate/lobbyist_employer_contributions.csv \
 	$(LOBBYIST_EMPLOYER_DATA_DIR)/intermediate/lobbyist_employer_expenditures.csv
 
-$(LOBBYIST_EMPLOYER_DATA_DIR)/processed/lobbyist_employer.xlsx : $(LOBBYIST_EMPLOYER_DATA_DIR)/intermediate/lobbyist_employer.csv      \
+data/processed/lobbyist_employer.xlsx : $(LOBBYIST_EMPLOYER_DATA_DIR)/intermediate/lobbyist_employer.csv      \
 								$(LOBBYIST_EMPLOYER_DATA_DIR)/processed/lobbyist_employer_contributions.csv \
 								$(LOBBYIST_EMPLOYER_DATA_DIR)/processed/lobbyist_employer_expenditures.csv
 	python scripts/to_excel.py $^ $@
@@ -40,5 +40,5 @@ $(LOBBYIST_EMPLOYER_DATA_DIR)/intermediate/lobbyist_employer.csv : $(LOBBYIST_EM
 	JOIN STDIN \
 	USING (LobbyMemberID, LobbyMemberversionid)" < $< > $@
 
-$(LOBBYIST_EMPLOYER_DATA_DIR)/raw/lobbyist_employer.csv : lobbyist_employer_LOBBYIST_EMPLOYER_DATA_DIRs
+$(LOBBYIST_EMPLOYER_DATA_DIR)/raw/lobbyist_employer.csv : lobbyist_employer_data_dirs
 	python -m scrapers.lobbyist.scrape_employers > $@

--- a/lobbyists.mk
+++ b/lobbyists.mk
@@ -1,17 +1,17 @@
 # Lobbyist expenditures and contributions
-DATA_DIR=data/lobbyist
+LOBBYIST_DATA_DIR=data/lobbyist
 
-.PRECIOUS : $(DATA_DIR)/raw/lobbyist.csv \
-	$(DATA_DIR)/intermediate/lobbyist_contributions.csv \
-	$(DATA_DIR)/intermediate/lobbyist_expenditures.csv
+.PRECIOUS : $(LOBBYIST_DATA_DIR)/raw/lobbyist.csv \
+	$(LOBBYIST_DATA_DIR)/intermediate/lobbyist_contributions.csv \
+	$(LOBBYIST_DATA_DIR)/intermediate/lobbyist_expenditures.csv
 
-$(DATA_DIR)/processed/lobbyist.xlsx : $(DATA_DIR)/processed/lobbyist_employer.csv      \
-								$(DATA_DIR)/processed/lobbyist_contributions.csv \
-								$(DATA_DIR)/processed/lobbyist_expenditures.csv
+$(LOBBYIST_DATA_DIR)/processed/lobbyist.xlsx : $(LOBBYIST_DATA_DIR)/processed/lobbyist_employer.csv      \
+								$(LOBBYIST_DATA_DIR)/processed/lobbyist_contributions.csv \
+								$(LOBBYIST_DATA_DIR)/processed/lobbyist_expenditures.csv
 	python scripts/to_excel.py $^ $@
 
-$(DATA_DIR)/processed/lobbyist_employer.csv : $(DATA_DIR)/raw/lobbyist.csv \
-	$(DATA_DIR)/intermediate/client.csv
+$(LOBBYIST_DATA_DIR)/processed/lobbyist_employer.csv : $(LOBBYIST_DATA_DIR)/raw/lobbyist.csv \
+	$(LOBBYIST_DATA_DIR)/intermediate/client.csv
 	csvsql --query "SELECT \
 		ClientID, \
 		MemberID,  \
@@ -36,19 +36,19 @@ $(DATA_DIR)/processed/lobbyist_employer.csv : $(DATA_DIR)/raw/lobbyist.csv \
 	USING (ClientID, MemberID, MemberVersionID, Year)" < $< | \
 	csvjoin -c ClientID - $(word 2, $^) > $@
 
-$(DATA_DIR)/processed/lobbyist_%.csv : $(DATA_DIR)/intermediate/lobbyist_%.csv \
-	$(DATA_DIR)/intermediate/filings.csv \
-	$(DATA_DIR)/intermediate/lobbyist.csv
+$(LOBBYIST_DATA_DIR)/processed/lobbyist_%.csv : $(LOBBYIST_DATA_DIR)/intermediate/lobbyist_%.csv \
+	$(LOBBYIST_DATA_DIR)/intermediate/filings.csv \
+	$(LOBBYIST_DATA_DIR)/intermediate/lobbyist.csv
 	csvjoin --left -c Source,ReportFileName $< $(word 2, $^) | \
 	csvjoin --left -c MemberID - $(word 3, $^) > $@
 
-$(DATA_DIR)/intermediate/lobbyist_%.csv : lobbyist_filings
-	python -m scrapers.lobbyist.extract_transactions $* $(DATA_DIR) > $@
+$(LOBBYIST_DATA_DIR)/intermediate/lobbyist_%.csv : lobbyist_filings
+	python -m scrapers.lobbyist.extract_transactions $* $(LOBBYIST_DATA_DIR) > $@
 
-lobbyist_filings : $(DATA_DIR)/intermediate/filings.csv
-	python -m scrapers.lobbyist.download_filings $(DATA_DIR) < $<
+lobbyist_filings : $(LOBBYIST_DATA_DIR)/intermediate/filings.csv
+	python -m scrapers.lobbyist.download_filings $(LOBBYIST_DATA_DIR) < $<
 
-$(DATA_DIR)/intermediate/lobbyist.csv : $(DATA_DIR)/raw/lobbyist.csv
+$(LOBBYIST_DATA_DIR)/intermediate/lobbyist.csv : $(LOBBYIST_DATA_DIR)/raw/lobbyist.csv
 	csvsql --query "SELECT \
 		MemberID,  \
 		Phone,  \
@@ -67,15 +67,15 @@ $(DATA_DIR)/intermediate/lobbyist.csv : $(DATA_DIR)/raw/lobbyist.csv
 	JOIN STDIN \
 	USING (MemberID, MemberVersionID, Year, ClientID)" < $< > $@
 
-$(DATA_DIR)/intermediate/filings.csv : $(DATA_DIR)/raw/lobbyist.csv
+$(LOBBYIST_DATA_DIR)/intermediate/filings.csv : $(LOBBYIST_DATA_DIR)/raw/lobbyist.csv
 	csvsql --query "SELECT DISTINCT MemberID AS id, MemberVersionID AS version FROM STDIN" < $< | \
 	python -m scrapers.lobbyist.scrape_filings > $@
 
-$(DATA_DIR)/raw/lobbyist.csv : $(DATA_DIR)/intermediate/client.csv
+$(LOBBYIST_DATA_DIR)/raw/lobbyist.csv : $(LOBBYIST_DATA_DIR)/intermediate/client.csv
 	python -m scrapers.lobbyist.scrape_lobbyists < $< > $@
 
-$(DATA_DIR)/intermediate/client.csv : $(DATA_DIR)/raw/client.csv
+$(LOBBYIST_DATA_DIR)/intermediate/client.csv : $(LOBBYIST_DATA_DIR)/raw/client.csv
 	csvsql --query "SELECT ClientID, ClientVersionID, MAX(ClientName) AS ClientName FROM STDIN GROUP BY ClientID" < $< > $@
 
-$(DATA_DIR)/raw/client.csv : lobbyist_data_dirs
+$(LOBBYIST_DATA_DIR)/raw/client.csv : lobbyist_LOBBYIST_DATA_DIRs
 	python -m scrapers.lobbyist.scrape_clients > $@

--- a/lobbyists.mk
+++ b/lobbyists.mk
@@ -69,7 +69,6 @@ $(DATA_DIR)/intermediate/lobbyist.csv : $(DATA_DIR)/raw/lobbyist.csv
 
 $(DATA_DIR)/intermediate/filings.csv : $(DATA_DIR)/raw/lobbyist.csv
 	csvsql --query "SELECT DISTINCT MemberID AS id, MemberVersionID AS version FROM STDIN" < $< | \
-	head -n 25 | \
 	python -m scrapers.lobbyist.scrape_filings > $@
 
 $(DATA_DIR)/raw/lobbyist.csv : $(DATA_DIR)/intermediate/client.csv

--- a/lobbyists.mk
+++ b/lobbyists.mk
@@ -69,7 +69,8 @@ $(LOBBYIST_DATA_DIR)/intermediate/lobbyist.csv : $(LOBBYIST_DATA_DIR)/raw/lobbyi
 
 $(LOBBYIST_DATA_DIR)/intermediate/filings.csv : $(LOBBYIST_DATA_DIR)/raw/lobbyist.csv
 	csvsql --query "SELECT DISTINCT MemberID AS id, MemberVersionID AS version FROM STDIN" < $< | \
-	python -m scrapers.lobbyist.scrape_filings > $@
+	python -m scrapers.lobbyist.scrape_filings | \
+	csvsql --query 'select ReportFileName, ReportTypeCode, MAX(MemberID) as MemberID from STDIN group by ReportFileName, ReportTypeCode' > $@
 
 $(LOBBYIST_DATA_DIR)/raw/lobbyist.csv : $(LOBBYIST_DATA_DIR)/intermediate/client.csv
 	python -m scrapers.lobbyist.scrape_lobbyists < $< > $@

--- a/lobbyists.mk
+++ b/lobbyists.mk
@@ -1,12 +1,17 @@
 # Lobbyist expenditures and contributions
-.PRECIOUS : data/intermediate/lobbyist_contributions.csv data/intermediate/lobbyist_expenditures.csv
+DATA_DIR=data/lobbyist
 
-data/processed/lobbyists.xlsx : data/processed/lobbyist_employer.csv      \
-								data/processed/lobbyist_contributions.csv \
-								data/processed/lobbyist_expenditures.csv
+.PRECIOUS : $(DATA_DIR)/raw/lobbyist.csv \
+	$(DATA_DIR)/intermediate/lobbyist_contributions.csv \
+	$(DATA_DIR)/intermediate/lobbyist_expenditures.csv
+
+$(DATA_DIR)/processed/lobbyist.xlsx : $(DATA_DIR)/processed/lobbyist_employer.csv      \
+								$(DATA_DIR)/processed/lobbyist_contributions.csv \
+								$(DATA_DIR)/processed/lobbyist_expenditures.csv
 	python scripts/to_excel.py $^ $@
 
-data/processed/lobbyist_employer.csv : data/raw/lobbyists.csv data/intermediate/clients.csv
+$(DATA_DIR)/processed/lobbyist_employer.csv : $(DATA_DIR)/raw/lobbyist.csv \
+	$(DATA_DIR)/intermediate/client.csv
 	csvsql --query "SELECT \
 		ClientID, \
 		MemberID,  \
@@ -31,19 +36,19 @@ data/processed/lobbyist_employer.csv : data/raw/lobbyists.csv data/intermediate/
 	USING (ClientID, MemberID, MemberVersionID, Year)" < $< | \
 	csvjoin -c ClientID - $(word 2, $^) > $@
 
-data/processed/lobbyist_%.csv : data/intermediate/lobbyist_%.csv data/intermediate/filings.csv \
-	data/intermediate/lobbyists.csv
+$(DATA_DIR)/processed/lobbyist_%.csv : $(DATA_DIR)/intermediate/lobbyist_%.csv \
+	$(DATA_DIR)/intermediate/filings.csv \
+	$(DATA_DIR)/intermediate/lobbyist.csv
 	csvjoin --left -c Source,ReportFileName $< $(word 2, $^) | \
 	csvjoin --left -c MemberID - $(word 3, $^) > $@
 
-data/intermediate/lobbyist_%.csv : filings
-	python -m scrapers.lobbyist.extract_transactions $* > $@
+$(DATA_DIR)/intermediate/lobbyist_%.csv : lobbyist_filings
+	python -m scrapers.lobbyist.extract_transactions $* $(DATA_DIR) > $@
 
-filings : data/intermediate/filings.csv
-	csvgrep -c ReportTypeCode -m "LNA" -i < $< | \
-	python -m scrapers.lobbyist.download_filings
+lobbyist_filings : $(DATA_DIR)/intermediate/filings.csv
+	python -m scrapers.lobbyist.download_filings $(DATA_DIR) < $<
 
-data/intermediate/lobbyists.csv : data/raw/lobbyists.csv
+$(DATA_DIR)/intermediate/lobbyist.csv : $(DATA_DIR)/raw/lobbyist.csv
 	csvsql --query "SELECT \
 		MemberID,  \
 		Phone,  \
@@ -62,26 +67,16 @@ data/intermediate/lobbyists.csv : data/raw/lobbyists.csv
 	JOIN STDIN \
 	USING (MemberID, MemberVersionID, Year, ClientID)" < $< > $@
 
-data/intermediate/clients.csv : data/raw/clients.csv
-	csvsql --query "SELECT ClientID, ClientVersionID, MAX(ClientName) AS ClientName FROM STDIN GROUP BY ClientID" < $< > $@
-
-# Concatenate individual lobbyist and lobbyist employer filings
-data/intermediate/filings.csv : data/intermediate/employer_filings.csv data/intermediate/individual_filings.csv
-	csvstack $^ > $@
-
-data/intermediate/individual_filings.csv : data/raw/lobbyists.csv
+$(DATA_DIR)/intermediate/filings.csv : $(DATA_DIR)/raw/lobbyist.csv
 	csvsql --query "SELECT DISTINCT MemberID AS id, MemberVersionID AS version FROM STDIN" < $< | \
+	head -n 25 | \
 	python -m scrapers.lobbyist.scrape_filings > $@
 
-data/intermediate/employer_filings.csv : data/raw/employers.csv
-	csvsql --query "SELECT DISTINCT LobbyMemberID AS id, LobbyMemberversionid AS version FROM STDIN" < $< | \
-	python -m scrapers.lobbyist.scrape_filings --employer > $@
-
-data/raw/lobbyists.csv : data/intermediate/clients.csv
+$(DATA_DIR)/raw/lobbyist.csv : $(DATA_DIR)/intermediate/client.csv
 	python -m scrapers.lobbyist.scrape_lobbyists < $< > $@
 
-data/raw/employers.csv : 
-	python -m scrapers.lobbyist.scrape_employers > $@
+$(DATA_DIR)/intermediate/client.csv : $(DATA_DIR)/raw/client.csv
+	csvsql --query "SELECT ClientID, ClientVersionID, MAX(ClientName) AS ClientName FROM STDIN GROUP BY ClientID" < $< > $@
 
-data/raw/clients.csv :
+$(DATA_DIR)/raw/client.csv : lobbyist_data_dirs
 	python -m scrapers.lobbyist.scrape_clients > $@

--- a/lobbyists.mk
+++ b/lobbyists.mk
@@ -5,7 +5,7 @@ LOBBYIST_DATA_DIR=data/lobbyist
 	$(LOBBYIST_DATA_DIR)/intermediate/lobbyist_contributions.csv \
 	$(LOBBYIST_DATA_DIR)/intermediate/lobbyist_expenditures.csv
 
-$(LOBBYIST_DATA_DIR)/processed/lobbyist.xlsx : $(LOBBYIST_DATA_DIR)/processed/lobbyist_employer.csv      \
+data/processed/lobbyist.xlsx : $(LOBBYIST_DATA_DIR)/processed/lobbyist_employer.csv      \
 								$(LOBBYIST_DATA_DIR)/processed/lobbyist_contributions.csv \
 								$(LOBBYIST_DATA_DIR)/processed/lobbyist_expenditures.csv
 	python scripts/to_excel.py $^ $@
@@ -77,5 +77,5 @@ $(LOBBYIST_DATA_DIR)/raw/lobbyist.csv : $(LOBBYIST_DATA_DIR)/intermediate/client
 $(LOBBYIST_DATA_DIR)/intermediate/client.csv : $(LOBBYIST_DATA_DIR)/raw/client.csv
 	csvsql --query "SELECT ClientID, ClientVersionID, MAX(ClientName) AS ClientName FROM STDIN GROUP BY ClientID" < $< > $@
 
-$(LOBBYIST_DATA_DIR)/raw/client.csv : lobbyist_LOBBYIST_DATA_DIRs
+$(LOBBYIST_DATA_DIR)/raw/client.csv : lobbyist_data_dirs
 	python -m scrapers.lobbyist.scrape_clients > $@

--- a/lobbyists.mk
+++ b/lobbyists.mk
@@ -1,6 +1,11 @@
 # Lobbyist expenditures and contributions
 .PRECIOUS : data/intermediate/lobbyist_contributions.csv data/intermediate/lobbyist_expenditures.csv
 
+data/processed/lobbyists.xlsx : data/processed/lobbyist_employer.csv      \
+								data/processed/lobbyist_contributions.csv \
+								data/processed/lobbyist_expenditures.csv
+	python scripts/to_excel.py $^ $@
+
 data/processed/lobbyist_employer.csv : data/raw/lobbyists.csv data/intermediate/clients.csv
 	csvsql --query "SELECT \
 		ClientID, \

--- a/scrapers/lobbyist/download_filings.py
+++ b/scrapers/lobbyist/download_filings.py
@@ -6,18 +6,13 @@ import sys
 from tqdm import tqdm
 
 
-def get_file_name(report_type_code, member_id, report_file_name):
-    os.makedirs(
-        os.path.join("data", "pdfs", report_type_code, member_id), exist_ok=True
-    )
+_, subdir = sys.argv
 
-    return os.path.join(
-        "data",
-        "pdfs",
-        report_type_code,
-        member_id,
-        report_file_name,
-    )
+
+def get_file_name(report_type_code, member_id, report_file_name):
+    report_path = os.path.join(subdir, "assets", report_type_code, member_id)
+    os.makedirs(report_path, exist_ok=True)
+    return os.path.join(report_path, report_file_name)
 
 
 reader = csv.DictReader(sys.stdin)
@@ -34,7 +29,11 @@ for row in tqdm(reader):
 
     filing_url = f"https://login.cfis.sos.state.nm.us//ReportsOutput//{row['ReportTypeCode']}/{row['ReportFileName']}"
 
-    response = requests.get(filing_url)
+    try:
+        response = requests.get(filing_url, verify=False)
+    except Exception as e:
+        print(f"Could not retrieve {filing_url}: {e}")
+        continue
 
     if response.ok:
         # LAR - Quarterly, LCD - 48-hour, LNA - No expenditures

--- a/scrapers/lobbyist/extract_transactions.py
+++ b/scrapers/lobbyist/extract_transactions.py
@@ -77,6 +77,7 @@ if __name__ == "__main__":
             itertools.chain(
                 os.walk(os.path.join(subdir, "assets/LAR")),
                 os.walk(os.path.join(subdir, "assets/LCD")),
+                os.walk(os.path.join(subdir, "assets/LNA")),
             )
         ):
             for file in files:

--- a/scrapers/lobbyist/extract_transactions.py
+++ b/scrapers/lobbyist/extract_transactions.py
@@ -36,7 +36,7 @@ def extract_transactions(pdf_obj, table_start_signature, table_end_signature):
 
 
 if __name__ == "__main__":
-    _, transaction_type = sys.argv
+    _, transaction_type, subdir = sys.argv
 
     if transaction_type == "expenditures":
         column_names = [
@@ -74,7 +74,10 @@ if __name__ == "__main__":
         null_writer.writerow(["Source", "File path"])
 
         for root, _, files in tqdm(
-            itertools.chain(os.walk("data/pdfs/LAR"), os.walk("data/pdfs/LCD"))
+            itertools.chain(
+                os.walk(os.path.join(subdir, "assets/LAR")),
+                os.walk(os.path.join(subdir, "assets/LCD")),
+            )
         ):
             for file in files:
                 if not file.endswith(".pdf"):


### PR DESCRIPTION
## Description

This PR separates the lobbyist and lobbyist employer pipelines for legibility (they are just different enough to be infuriating if combined), and updates the final target of both pipelines to be an Excel workboook containing a list of lobbyists/lobbyist employers and their contributions / expenditures.

It also adapts some of the lobbyist scraping scripts to accept a subdirectory to read from or write to, in service of separating the pipelines.

### Testing instructions

See successful run at https://github.com/datamade/nmid-scrapers/actions/runs/11280780145